### PR TITLE
fix(nghttp2): CVE-2022-0240

### DIFF
--- a/nghttp2/third-party/mruby/src/class.c
+++ b/nghttp2/third-party/mruby/src/class.c
@@ -104,6 +104,7 @@ prepare_singleton_class(mrb_state *mrb, struct RBasic *o)
 {
   struct RClass *sc, *c;
 
+  mrb_assert(o->c);
   if (o->c->tt == MRB_TT_SCLASS) return;
   sc = (struct RClass*)mrb_obj_alloc(mrb, MRB_TT_SCLASS, mrb->class_class);
   sc->flags |= MRB_FL_CLASS_IS_INHERITED;
@@ -1284,6 +1285,7 @@ mrb_singleton_class_ptr(mrb_state *mrb, mrb_value v)
     break;
   }
   obj = mrb_basic_ptr(v);
+  if (obj->c == NULL) return NULL;
   prepare_singleton_class(mrb, obj);
   return obj->c;
 }


### PR DESCRIPTION
### Background
mruby could hit a NULL pointer dereference in the singleton-class path when an object’s class pointer (`obj->c`) is NULL and code proceeds into `prepare_singleton_class()` / accesses `o->c`, tracked as https://github.com/advisories/GHSA-r744-r36f-363j.

### Changes
Add a defensive `obj->c`/`o->c` check before calling `prepare_singleton_class()` and before dereferencing `o->c`; return NULL early when `obj->c` is missing and assert `o->c` where appropriate.

### Security Impact
Prevents a crash/DoS via NULL pointer dereference in mruby’s singleton-class handling, addressing https://github.com/advisories/GHSA-r744-r36f-363j.

References
Upstream commit: 31fa3304049fc406a201a72293cce140f0557dca; CVE: https://github.com/advisories/GHSA-r744-r36f-363j

All credits goes to @Mifacopy - https://github.com/ErikMinekus/sm-ripext/pull/81