### PR TITLE
chore(ci): pin SM to master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2022]
-        sourcemod-version: [1.12-dev]
+        sourcemod-version: [master]
         python-version: ['3.10']
         include:
           - os: ubuntu-22.04

--- a/extension.h
+++ b/extension.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <curl/curl.h>
 #include <jansson.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <stdlib.h>
 #include <string.h>
 #include <uv.h>


### PR DESCRIPTION
## Fix

- Pin the SourceMod checkout to a stable branch/tag instead of `master`, so upstream internal refactors don't break our CI without  warning.
 - Replace outdated header `<sm_stringhashmap.h>` with `<sm_hashmap.h>`